### PR TITLE
Test scenarios should say the  not  these 

### DIFF
--- a/source/documentation/test-scenarios.html.md.erb
+++ b/source/documentation/test-scenarios.html.md.erb
@@ -15,7 +15,7 @@ To test this endpoint in the External Test environment, you will need to provide
 
 ### Get messages
 
-If you also want to test the endpoint ['Get all messages for an excise movement using the movementId'](#endpoint-get-all-messages-for-an-excise-movement-using-the-movementid), you must use one of these LRNs in that section.
+If you also want to test the endpoint ['Get all messages for an excise movement using the movementId'](#endpoint-get-all-messages-for-an-excise-movement-using-the-movementid), you must use one of the LRNs in that section.
 
 ### Error cases
 


### PR DESCRIPTION
Test scenarios should say "the"  not  "these" as that gives impression they are going to be listed below whereas they are contained in the section that has hyperlink